### PR TITLE
Fix query condition for snippet visibility

### DIFF
--- a/db/queries.ts
+++ b/db/queries.ts
@@ -20,8 +20,7 @@ export async function getSnippet(id: number, preview: boolean = false) {
           eq(snippetTable.id, id),
           or(
             eq(snippetTable.visibility, "public"),
-            eq(snippetTable.userId, userId ?? ""),
-            preview ? eq(snippetTable.visibility, "private") : undefined
+            eq(snippetTable.userId, userId ?? ""),      
           )
         )
       )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the visibility filter in `getSnippet` so private snippets aren’t exposed via the preview flag. Only public snippets or those owned by the current user are returned.

- **Bug Fixes**
  - Removed the `preview`-based allowance from the `or(...)` condition in `getSnippet`, keeping only `public` visibility or `userId === current user`. Prevents accessing other users’ private snippets during preview.

<sup>Written for commit f6c505452ae50112599ce97ab6da80e7439d468f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Vaib215/snippets/pull/16?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

